### PR TITLE
feat(core): add output option

### DIFF
--- a/misc/a/tsconfig.json
+++ b/misc/a/tsconfig.json
@@ -6,10 +6,7 @@
         "outDir": "dist"
     },
     "filesGlob": [
-        "src/**/*.ts",
-        "!ignored/**/*.ts"
-    ],
-    /* GENERATED: DON'T EDIT */
-    "files": [
+        "../src/**/*.ts",
+        "!../src/ignored/**/*.ts"
     ]
 }

--- a/misc/b/_tsconfig.json
+++ b/misc/b/_tsconfig.json
@@ -6,11 +6,7 @@
         "outDir": "dist"
     },
     "filesGlob": [
-        "src/**/*.ts",
-        "!ignored/**/*.ts"
-    ],
-    "files": [
-        "src/bar.ts",
-        "src/foo.ts"
+        "../src/**/*.ts",
+        "!../src/ignored/**/*.ts"
     ]
 }

--- a/misc/c/my-tsconfig.json
+++ b/misc/c/my-tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "outDir": "dist"
+    },
+    "filesGlob": [
+        "../src/**/*.ts",
+        "!../src/ignored/**/*.ts"
+    ]
+}

--- a/misc/d/_my-tsconfig.json
+++ b/misc/d/_my-tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "outDir": "dist"
+    },
+    "filesGlob": [
+        "../src/**/*.ts",
+        "!../src/ignored/**/*.ts"
+    ]
+}

--- a/misc/e/tsconfig.proto.json
+++ b/misc/e/tsconfig.proto.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "outDir": "dist"
+    },
+    "filesGlob": [
+        "../src/**/*.ts",
+        "!../src/ignored/**/*.ts"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "setup": "npm install",
     "build": "babel index.js -o tsconfig && babel test.js -o test.transpiled.js",
     "pretest": "eslint index.js",
-    "test": "npm run build && node tsconfig misc/tsconfig.commented.json -u -v && mocha test.transpiled.js",
+    "test": "npm run build && mocha test.transpiled.js",
     "postversion": "npm run changelog",
     "changelog": "node tools/changelog.js",
     "postchangelog": "git add -u && git commit -m 'docs(changelog): Update CHANGELOG.md'"
@@ -20,7 +20,9 @@
     "tsconfig"
   ],
   "author": "laco0416 <laco0416@gmail.com>",
-  "repository": "https://github.com/laco0416/tsconfig-cli",
+  "repository": {
+    "url": "https://github.com/laco0416/tsconfig-cli"
+  },
   "license": "MIT",
   "dependencies": {
     "commander": "^2.9.0",

--- a/test.js
+++ b/test.js
@@ -1,14 +1,101 @@
 "use strict";
 
-import assert from "assert";
+const assert = require("assert");
+const fs = require("fs");
+const exec = require("child_process").exec;
 
 describe("tsconfig result", () => {
-  it("should match files", () => {
-    let config = require("./misc/tsconfig.json");
-    let expected = [
-      "src/bar.ts",
-      "src/foo.ts"
+
+  before(() => {
+    let list = [
+      "misc/b/tsconfig.json",
+      "misc/d/my-tsconfig.json",
+      "misc/e/tsconfig.json",
     ];
-    assert.deepEqual(config.files, expected);
+
+    list.forEach(path => {
+      if (fs.existsSync(path)) {
+        fs.unlinkSync(path);
+      }
+    });
+  });
+
+  after(() => {
+    let list = [
+      "misc/b/tsconfig.json",
+      "misc/d/my-tsconfig.json",
+      "misc/e/tsconfig.json",
+    ];
+
+    list.forEach(path => {
+      if (fs.existsSync(path)) {
+        fs.unlinkSync(path);
+      }
+    });
+  });
+
+  describe("case:a (no args)", () => {
+    it("should keep the origin file", (done) => {
+      let before = fs.readFileSync("misc/a/tsconfig.json").toString();
+      exec("cd misc/a && node ../../tsconfig", () => {
+        let after = fs.readFileSync("misc/a/tsconfig.json").toString();
+        assert(before === after);
+        done();
+      });
+    })
+  });
+
+  describe("case:b (only -u)", () => {
+    it("should update the origin file", (done) => {
+      let proto = fs.readFileSync("misc/b/_tsconfig.json").toString();
+      fs.writeFileSync("misc/b/tsconfig.json", proto);
+      let before = fs.readFileSync("misc/b/tsconfig.json").toString();
+      exec("cd misc/b && node ../../tsconfig -u", () => {
+        let after = fs.readFileSync("misc/b/tsconfig.json").toString();
+        assert(before !== after);
+        let expected = [
+          "../src/bar.ts",
+          "../src/foo.ts"
+        ];
+        assert.deepEqual(require("./misc/b/tsconfig.json").files, expected);
+        done();
+      });
+    })
+  });
+
+  describe("case:c (only arg)", () => {
+    it("should keep the origin file", (done) => {
+      let before = fs.readFileSync("misc/c/my-tsconfig.json").toString();
+      exec("cd misc/c && node ../../tsconfig my-tsconfig.json", () => {
+        let after = fs.readFileSync("misc/c/my-tsconfig.json").toString();
+        assert(before === after);
+        done();
+      });
+    })
+  });
+
+  describe("case:d (-u & arg)", () => {
+    it("should update the origin file", (done) => {
+      let proto = fs.readFileSync("misc/d/_my-tsconfig.json").toString();
+      fs.writeFileSync("misc/d/my-tsconfig.json", proto);
+
+      let before = fs.readFileSync("misc/d/my-tsconfig.json").toString();
+      exec("cd misc/d && node ../../tsconfig -u my-tsconfig.json", () => {
+        let after = fs.readFileSync("misc/d/my-tsconfig.json").toString();
+        assert(before !== after);
+        done();
+      });
+    });
+  });
+
+  describe("case:e (-o & arg)", () => {
+    it("should overwrite the output file", (done) => {
+      let before = fs.readFileSync("misc/e/tsconfig.proto.json").toString();
+      exec("cd misc/e && node ../../tsconfig -o tsconfig.json tsconfig.proto.json", () => {
+        let after = fs.readFileSync("misc/e/tsconfig.json").toString();
+        assert(before !== after);
+        done();
+      });
+    });
   });
 });

--- a/tsconfig
+++ b/tsconfig
@@ -21,13 +21,12 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var FILE_NAME = "tsconfig.json";
-
-_commander2.default.version(require("./package.json").version).usage("[options] filepath\n  if the file includes comments, those will be striped.").option("-u, --update", "Update tsconfig.json").option("-v, --verbose", "Print verbose logs").parse(process.argv);
+_commander2.default.version(require("./package.json").version).usage("[options] filepath\n  if the file includes comments, those will be striped.").option("-u, --update", "Update the file").option("-o, --output <output>", "Output file path").option("-v, --verbose", "Print verbose logs").parse(process.argv);
 
 var opt = {};
 opt.args = _commander2.default.args;
 opt.update = _commander2.default.update || false;
+opt.output = _commander2.default.output || "";
 opt.verbose = _commander2.default.verbose || false;
 
 var log = function log(str) {
@@ -46,7 +45,7 @@ new Promise(function (resolve, reject) {
   resolve();
 }).then(function () {
   // Check file existence
-  var cfgPath = opt.args[0] || FILE_NAME;
+  var cfgPath = opt.args[0] || "tsconfig.json";
   return new Promise(function (resolve, reject) {
     _fs2.default.stat(cfgPath, function (err) {
       if (err) {
@@ -58,7 +57,11 @@ new Promise(function (resolve, reject) {
 }).then(function (inputPath) {
   log("\tInput:\t\"" + inputPath + "\"");
   var projectDir = _path2.default.dirname(inputPath);
-  opt.outputPath = projectDir + "/" + FILE_NAME;
+  if (opt.output) {
+    opt.outputPath = _path2.default.resolve(projectDir, opt.output);
+  } else {
+    opt.outputPath = projectDir + "/" + _path2.default.basename(inputPath);
+  }
   // Load tsconfig.json
   return tsconfig.readFile(inputPath).then(function (result) {
     // Resolve files into relative path
@@ -72,7 +75,7 @@ new Promise(function (resolve, reject) {
 }).then(function (tsconfig) {
   // Output
   var p = void 0;
-  if (opt.update) {
+  if (opt.update || opt.output) {
     // Overwrite tsconfig.json
     p = new Promise(function (resolve, reject) {
       _fs2.default.writeFile(opt.outputPath, JSON.stringify(tsconfig, null, 4), function (err) {


### PR DESCRIPTION
BREAKING CHANGES

When you use `-u` option, an input file will be overwritten ALWAYS.

 If you want to separate input and output files, use `-o` option.

 BEFORE:

 ```
 $ tsconfig -u tsconfig.proto.json
 ```

 AFTER

 ```
 $ tsconfig -o tsconfig.json tsconfig.proto.json
 ```

Close #7